### PR TITLE
add user name and email to test token helper

### DIFF
--- a/lib/ided_client/test_helpers.rb
+++ b/lib/ided_client/test_helpers.rb
@@ -1,11 +1,11 @@
 module IdedClient
   module TestHelpers
     class << self
-      def user_test_token(id = SecureRandom.uuid, exp = 7200)
+      def user_test_token(id: SecureRandom.uuid, user_email: "test@example.com", user_name: "Bob McTester", exp: 7200)
         payload = {
           sub: id,
-          user_email: "test@example.com",
-          user_name: "Bob McTester",
+          user_email: user_email,
+          user_name: user_name,
           exp: Time.now.utc.to_i + exp,
         }
         JWT.encode(payload, private_key, "RS512")

--- a/spec/lib/ided_client/test_helpers_spec.rb
+++ b/spec/lib/ided_client/test_helpers_spec.rb
@@ -3,10 +3,13 @@ require "ided_client/test_helpers"
 
 RSpec.describe IdedClient::TestHelpers do
   it "allows a token to be generated and decoded" do
-    token = described_class.user_test_token("pizza-id")
+    token = described_class.user_test_token(id: "pizza-id", user_email: "stevemctester@test.com", user_name: "steven")
     expect(token).to be_present
 
     payload = JWT.decode token, described_class.public_key, true, { algorithm: "RS512" }
+
     expect(payload[0]).to include("sub" => "pizza-id")
+    expect(payload[0]).to include("user_email" => "stevemctester@test.com")
+    expect(payload[0]).to include("user_name" => "steven")
   end
 end


### PR DESCRIPTION
why: so this information is available in tests